### PR TITLE
Handle empty s3 files to prevent table truncation

### DIFF
--- a/import_S3_to_snowflake_csv.sql
+++ b/import_S3_to_snowflake_csv.sql
@@ -74,34 +74,49 @@ macros/import_S3_to_snowflake_csv.sql
 
 
 
-    {% set copy_into_query %}
+    {% set load_table = 'load_' ~ table %}
 
-        TRUNCATE TABLE {{database}}.{{schema}}.{{table}}; {# Clear staging table before copy #}
+    {% set guarded_load %}
+        DECLARE
+            row_count NUMBER := 0;
+        BEGIN
+            CREATE OR REPLACE TABLE {{database}}.{{schema}}.{{load_table}} LIKE {{database}}.{{schema}}.{{table}};
 
-        COPY INTO {{database}}.{{schema}}.{{table}}
-        FROM {{location}} 
-        storage_integration = {{ env_var("DBT_S3_TO_SNOWFLAKE_INT") }}
-        PATTERN = '{{ pattern }}'
-        FILE_FORMAT = (
-            TYPE=csv
-            COMPRESSION=AUTO,
-            FIELD_DELIMITER = ',',
-            SKIP_HEADER=1,
-            SKIP_BLANK_LINES=TRUE,
-            TRIM_SPACE=TRUE,
-            FIELD_OPTIONALLY_ENCLOSED_BY='"',
-            {{ null_if }} {# whole line is omitted if no values present for null_if conditions #}
-            ERROR_ON_COLUMN_COUNT_MISMATCH=TRUE,
-            REPLACE_INVALID_CHARACTERS=TRUE,
-            EMPTY_FIELD_AS_NULL=TRUE
-        )
-        ON_ERROR='{{ on_error }}'
-        PURGE=FALSE
-        TRUNCATECOLUMNS=FALSE
-        FORCE=FALSE
-      
+            COPY INTO {{database}}.{{schema}}.{{load_table}}
+            FROM {{location}}
+            storage_integration = {{ env_var("DBT_S3_TO_SNOWFLAKE_INT") }}
+            PATTERN = '{{ pattern }}'
+            FILE_FORMAT = (
+                TYPE=csv
+                COMPRESSION=AUTO,
+                FIELD_DELIMITER = ',',
+                SKIP_HEADER=1,
+                SKIP_BLANK_LINES=TRUE,
+                TRIM_SPACE=TRUE,
+                FIELD_OPTIONALLY_ENCLOSED_BY='"',
+                {{ null_if }} {# whole line is omitted if no values present for null_if conditions #}
+                ERROR_ON_COLUMN_COUNT_MISMATCH=TRUE,
+                REPLACE_INVALID_CHARACTERS=TRUE,
+                EMPTY_FIELD_AS_NULL=TRUE
+            )
+            ON_ERROR='{{ on_error }}'
+            PURGE=FALSE
+            TRUNCATECOLUMNS=FALSE
+            FORCE=FALSE
+            ;
 
+            SELECT COUNT(*) INTO :row_count FROM {{database}}.{{schema}}.{{load_table}};
+
+            IF (row_count = 0) THEN
+                DROP TABLE IF EXISTS {{database}}.{{schema}}.{{load_table}};
+                RAISE STATEMENT_ERROR WITH MESSAGE = 'S3 import aborted: no data found for {{location}} with pattern {{pattern}}';
+            ELSE
+                TRUNCATE TABLE {{database}}.{{schema}}.{{table}};
+                INSERT INTO {{database}}.{{schema}}.{{table}}
+                SELECT * FROM {{database}}.{{schema}}.{{load_table}};
+            END IF;
+        END;
     {% endset %}
-    {{copy_into_query}}
+    {{ guarded_load }}
 
 {% endmacro %}


### PR DESCRIPTION
Prevent target table truncation and stop model execution if S3 source file is empty.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff4b58ad-6e50-4723-aeb8-d95e9254fce5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ff4b58ad-6e50-4723-aeb8-d95e9254fce5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

